### PR TITLE
Print/log unhandled exceptions

### DIFF
--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -79,6 +79,9 @@ class MessageSender(threading.Thread):
             self._connected = False
 
         except Exception as e:
+            # Ensure that we record any unexpected exceptions in the logs.  We also print out
+            # the error, in order to still produce diagnosable output when we're hitting
+            # exceptions in the logging library.
             details = traceback.format_exc()
             error = ("ERROR - Hit exception in SAS sender thread!  SAS logs will no longer be "
                     "made.\n{}".format(details))


### PR DESCRIPTION
As part of debugging problems with our Python application, which uses `sasclient.py`, I made some modifications to the logging in the sender thread.  Specifically:
 - If an unhandled exception is thrown by the sender thread, we will now print it to `stdout` and log it.  The printing may seem unnecessary, but it is particularly useful if the unhandled exception that you hit is being thrown by the logging library.
 - I made the "Successfully sent message" conditional, such that it isn't sent for every heartbeat.  I could easily be persuaded to put this back, but it seemed like overkill to have 5 of these logs every second when debug logging was enabled.
