### PR TITLE
SAS client thread dies if SAS goes down

### DIFF
--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -125,7 +125,7 @@ class MessageSender(threading.Thread):
         try:
             self._sas_sock.shutdown(socket.SHUT_RDWR)
             self._sas_sock.close()
-        catch OSError:
+        except OSError:
             # Ignore errors that occur while trying to close a socket.  If the
             # connection has gone away, we don't have anything more to do.
             logger.info("Hit error closing socket - ignore")

--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -122,8 +122,13 @@ class MessageSender(threading.Thread):
         # It's possible that the socket doesn't even exist yet, so we have nothing to do.
         if self._sas_sock is None:
             return
-        self._sas_sock.shutdown(socket.SHUT_RDWR)
-        self._sas_sock.close()
+        try:
+            self._sas_sock.shutdown(socket.SHUT_RDWR)
+            self._sas_sock.close()
+        catch OSError:
+            # Ignore errors that occur while trying to close a socket.  If the
+            # connection has gone away, we don't have anything more to do.
+            logger.info("Hit error closing socket - ignore")
 
     def send_message(self, message):
         """

--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -103,11 +103,12 @@ class MessageSender(threading.Thread):
             logger.info("Connecting to: %s:%s", self._sas_address, self._sas_port)
             self._sas_sock = socket.create_connection((self._sas_address, self._sas_port),
                                                       CONNECTION_TIMEOUT)
-        except IOError:
-            logger.exception(
-                "An I/O error occurred whilst opening socket to %s on port %s",
+        except IOError as e:
+            logger.error(
+                "An I/O error occurred whilst opening socket to %s on port %s: %s",
                 self._sas_address,
-                self._sas_port)
+                self._sas_port,
+                str(e))
         else:
             # Send the Init message, bypassing the queue.
             init = messages.Init(self._system_name, self._system_type, self._resource_identifier)
@@ -118,7 +119,7 @@ class MessageSender(threading.Thread):
                 self._connected = True
 
     def disconnect(self):
-        logger.info("Disconnecting")
+        logger.debug("Disconnecting")
         # It's possible that the socket doesn't even exist yet, so we have nothing to do.
         if self._sas_sock is None:
             return
@@ -149,13 +150,13 @@ class MessageSender(threading.Thread):
                 logger.debug("Successfully sent message")
 
             return True
-        except IOError:
-            logger.exception("An I/O error occurred whilst sending message to %s on port %s.",
-                             self._sas_address, self._sas_port)
+        except IOError as e:
+            logger.error("An I/O error occurred whilst sending message to %s on port %s: %s",
+                         self._sas_address, self._sas_port, str(e))
             return False
-        except socket.timeout:
-            logger.exception("Socket timeout occurred whilst sending message to %s on port %s.",
-                             self._sas_address, self._sas_port)
+        except socket.timeout as e:
+            logger.error("Socket timeout occurred whilst sending message to %s on port %s: %s",
+                         self._sas_address, self._sas_port, str(e))
             return False
 
     def reconnect(self):

--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -126,10 +126,10 @@ class MessageSender(threading.Thread):
         try:
             self._sas_sock.shutdown(socket.SHUT_RDWR)
             self._sas_sock.close()
-        except Exception:
+        except Exception as e:
             # Ignore errors that occur while trying to close a socket.  If the
             # connection has gone away, we don't have anything more to do.
-            logger.debug("Hit error closing socket - ignore")
+            logger.debug("Hit error closing socket - ignore: %s", str(e))
 
     def send_message(self, message):
         """

--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -125,10 +125,10 @@ class MessageSender(threading.Thread):
         try:
             self._sas_sock.shutdown(socket.SHUT_RDWR)
             self._sas_sock.close()
-        except OSError:
+        except Exception:
             # Ignore errors that occur while trying to close a socket.  If the
             # connection has gone away, we don't have anything more to do.
-            logger.info("Hit error closing socket - ignore")
+            logger.debug("Hit error closing socket - ignore")
 
     def send_message(self, message):
         """


### PR DESCRIPTION
This is a fix for the issue spotted in Houdini testing where the `sasclient.py` library permanently fails if the network connection to the SAS is lost (https://github.com/Metaswitch/houdini/issues/712).

Now we will ignore failures that occur while trying to disconnect from a socket.  Previously such exceptions were thrown up to the top, and killed the single SAS sender thread, preventing any sort of recovery.  Now the client will automatically reconnect to SAS if/when it comes back on the network.

I've tested this by bringing SAS up and down, and seeing that the client now successfully reconnects.

I've also adjusted the error logging, as previously we'd spam the logs with lots of unhelpful details all the time we were down.  Now (at the default INFO logging level) we just get these two logs repeated every 5 seconds during periods of disconnection:
```
2017-06-02 13:30:33,529 INFO      sender.py:103 - Connecting to: 10.0.23.100:6761
2017-06-02 13:30:33,530 ERROR     sender.py:111 - An I/O error occurred whilst opening socket to 10.0.23.100 on port 6761: [Errno 111] Connection refused
```
