### PR TITLE
Add zlib compression support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: setup.py env
 .PHONY: coverage
 coverage: setup.py env
 	PYTHONPATH=src bash -c "${ENV_DIR}/bin/python ${ENV_DIR}/bin/coverage run --source src test/run_tests.py"
-	 bash -c "${ENV_DIR}/bin/python ${ENV_DIR}/bin/coverage report -m"
+	 bash -c "${ENV_DIR}/bin/python ${ENV_DIR}/bin/coverage report -m --fail-under=100 --omit=*main.py,*sender.py"
 
 verify:
 	flake8 --select=E10,E11,E9,F src test

--- a/src/metaswitch/sasclient/constants.py
+++ b/src/metaswitch/sasclient/constants.py
@@ -63,4 +63,7 @@ MARKER_ID_INBOUND_CALLING_URI = 0x05000004
 MARKER_ID_OUTBOUND_CALLED_URI = 0x05000005
 MARKER_ID_INBOUND_CALLED_URI = 0x05000006
 
+# Compression constants
+COMPRESS_ZLIB = "zlib"
+
 # For event IDs and usage, see your resource bundle

--- a/src/metaswitch/sasclient/messages.py
+++ b/src/metaswitch/sasclient/messages.py
@@ -213,7 +213,7 @@ class DataMessage(Message):
         if compress == COMPRESS_ZLIB:
             # Compress with zlib
             enc_value = zlib.compress(enc_value)
-        else if compress is not None:
+        elif compress is not None:
             # Unrecognised compression type
             raise ValueError("Unrecognised compression type: {}".format(compress))
 

--- a/src/metaswitch/sasclient/messages.py
+++ b/src/metaswitch/sasclient/messages.py
@@ -4,6 +4,7 @@
 import struct
 import time
 import datetime
+import zlib
 from metaswitch.sasclient.constants import (
     FLAG_ASSOCIATE,
     FLAG_NO_REACTIVATE,
@@ -16,7 +17,8 @@ from metaswitch.sasclient.constants import (
     MESSAGE_STRINGS,
     MESSAGE_TRAIL_ASSOCIATION,
     PROTOCOL_VERSION,
-    SCOPE_NONE)
+    SCOPE_NONE,
+    COMPRESS_ZLIB)
 
 # The base event ID for all events specified by resource bundles.
 RESOURCE_BUNDLE_BASE = 0x0F000000
@@ -174,20 +176,17 @@ class DataMessage(Message):
     def __init__(self, static_params, var_params):
         super(DataMessage, self).__init__()
         self.static_params = static_params[:]
-        self.var_params = var_params[:]
+        self.var_params = []
+        self.add_variable_params(var_params)
 
     def serialize_params(self):
         static_data = ''.join(
             [struct.pack('=i', static_param) for static_param in self.static_params])
         static_data = struct.pack('!h', len(static_data)) + static_data
 
-        encoded_var_params = [
-            var_param.encode('UTF-8')
-            if isinstance(var_param, unicode) else str(var_param)
-            for var_param in self.var_params]
         var_data = ''.join([
-            struct.pack('!h', len(var_param)) + str(var_param)
-            for var_param in encoded_var_params])
+            struct.pack('!h', len(var_param)) + var_param
+            for var_param in self.var_params])
 
         return static_data + var_data
 
@@ -202,14 +201,23 @@ class DataMessage(Message):
         self.static_params.append(static_param)
         return self
 
-    def add_variable_params(self, var_params):
+    def add_variable_params(self, var_params, compress=None):
         if not isinstance(var_params, list):
             raise TypeError("Expecting a list")
-        self.var_params += var_params
+        [self.add_variable_param(p, compress) for p in var_params]
         return self
 
-    def add_variable_param(self, var_param):
-        self.var_params.append(var_param)
+    def add_variable_param(self, var_param, compress=None):
+        enc_value = var_param.encode('UTF-8') if isinstance(var_param, unicode) else str(var_param)
+
+        if compress == COMPRESS_ZLIB:
+            # Compress with zlib
+            enc_value = zlib.compress(enc_value)
+        else if compress is not None:
+            # Unrecognised compression type
+            raise ValueError("Unrecognised compression type: {}".format(compress))
+
+        self.var_params.append(enc_value)
         return self
 
     def __str__(self):

--- a/test/tests/test_sasclient_event.py
+++ b/test/tests/test_sasclient_event.py
@@ -1,4 +1,4 @@
-from metaswitch.sasclient import Event, Trail
+from metaswitch.sasclient import Event, Trail, COMPRESS_ZLIB
 from test_sasclient import SASClientTestCase
 
 TIMESTAMP = 1450180692598
@@ -21,6 +21,10 @@ EVENT_STRING_ONE_VAR = (
 EVENT_STRING_TWO_VAR = (
     '\x00D\x03\x03\x00\x00\x01Q\xa5\x81Jv\x00\x00\x00\x00\x00\x00\x00o\x0f\x00\x00\xde\x00\x00\x00'
     '\x00\x00\x00\x00\x0etest parameter\x00\x14other test parameter'
+)
+EVENT_STRING_COMPRESSED_VAR = (
+    '\x006\x03\x03\x00\x00\x01Q\xa5\x81Jv\x00\x00\x00\x00\x00\x00\x00o\x0f\x00\x00\xde\x00\x00\x00'
+    '\x00\x00\x00\x00\x16x\x9c+I-.Q(H,J\xccM-I-\x02\x00)\xd0\x05\xa2'
 )
 EVENT_STRING_ALL = (
     '\x00L\x03\x03\x00\x00\x01Q\xa5\x81Jv\x00\x00\x00\x00\x00\x00\x00o\x0f\x00\x00\xde\x00\x00\x02'
@@ -58,6 +62,16 @@ class SASClientEventTest(SASClientTestCase):
         self.assertEqual(event.serialize(), EVENT_STRING_TWO_VAR)
         # Now just check that __str__ doesn't throw
         self.assertGreater(len(str(event)), 0)
+
+    def test_compressed_variable_param(self):
+        event = Event(Trail(), 222).set_timestamp(TIMESTAMP)
+        event.add_variable_param("test parameter", compress=COMPRESS_ZLIB)
+        self.assertEqual(event.serialize(), EVENT_STRING_COMPRESSED_VAR)
+
+    def test_unknown_compression(self):
+        event = Event(Trail(), 222).set_timestamp(TIMESTAMP)
+        with self.assertRaises(ValueError):
+            event.add_variable_param("test parameter", compress='bogus_compression')
 
     def test_params_no_list(self):
         event = Event(Trail(), 222).set_timestamp(TIMESTAMP)


### PR DESCRIPTION
The library was unable to add compressed variable data.  I've added the one compression method that I needed ("zlib") for the work I was doing.  I have not attempted to make the library generically cope with any compression method, but I've specified the compression as a type parameter, allowing for easy future extension, without changing the interface.

Now it is possible to specify the `compress` parameter on calls to `add_variable_param()` and `add_variable_params()` - e.g.:
```python
event = Event(trail_id, event_id)
event.add_variable_param(param_text, compress=COMPRESS_ZLIB)
```