### PR TITLE
Add target to build a wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ $(ENV_DIR)/bin/coverage: $(ENV_DIR)/bin/python
 build_sasclient_egg: $(ENV_DIR)/bin/python setup.py
 	$(ENV_DIR)/bin/python setup.py bdist_egg -d $(EGG_DIR)
 
+.PHONY: build_sasclient_wheel
+build_sasclient_wheel: $(ENV_DIR)/bin/python setup.py
+	$(ENV_DIR)/bin/python setup.py bdist_wheel -d $(WHEELHOUSE)
+
 $(ENV_DIR)/.eggs_installed: $(ENV_DIR)/bin/python setup.py $(shell find src -type f -not -name "*.pyc")
 	$(ENV_DIR)/bin/python setup.py bdist_egg -d .eggs
 


### PR DESCRIPTION
Huw,

We are looking at improving our Python infrastructure to allow us to pin dependencies correctly - see https://github.com/Metaswitch/crest/pull/362 and related pull requests.

As part of that, it'd be useful if the Python SAS Client could build into a wheel (the modern version of python packaging) instead of an egg.

For now, I've left building eggs alone, although we may wish to remove this in the future. I've also not changed the way SAS Client internally installs an environment for testing.
