### PR TITLE
Limit message queue length

### DIFF
--- a/src/metaswitch/sasclient/main.py
+++ b/src/metaswitch/sasclient/main.py
@@ -10,6 +10,7 @@ from metaswitch.sasclient import sender
 DEFAULT_SAS_PORT = 6761
 
 # The number of messages to queue if no value is provided.
+MINIMUM_QUEUE_LENGTH = 100
 DEFAULT_QUEUE_LENGTH = 10000
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ class Client(object):
         :param start: Whether the SAS client should start immediately
         :param queue_length: The maximum number of messages to queue for sending to SAS
         """
+        queue_length = max(queue_length, MINIMUM_QUEUE_LENGTH)
         self._queue = Queue.Queue(maxsize=queue_length)
         self._stopper = None
         self._worker = None

--- a/src/metaswitch/sasclient/main.py
+++ b/src/metaswitch/sasclient/main.py
@@ -94,7 +94,7 @@ class Client(object):
     def send(self, message):
         logger.debug("Queueing message for sending:\n%s", str(message))
         try:
-            self._queue.put(message)
+            self._queue.put(message, block=False)
         except Queue.Full:
             self._worker.set_discarding()
 

--- a/src/metaswitch/sasclient/main.py
+++ b/src/metaswitch/sasclient/main.py
@@ -9,11 +9,20 @@ from metaswitch.sasclient import sender
 # The default SAS port, at the moment not configurable
 DEFAULT_SAS_PORT = 6761
 
+# The number of messages to queue if no value is provided.
+DEFAULT_QUEUE_LENGTH = 10000
+
 logger = logging.getLogger(__name__)
 
 
 class Client(object):
-    def __init__(self, system_name, system_type, resource_identifier, sas_address, start=True):
+    def __init__(self,
+                 system_name,
+                 system_type,
+                 resource_identifier,
+                 sas_address,
+                 start=True,
+                 queue_length=DEFAULT_QUEUE_LENGTH):
         """
         Constructs the client and the message queue.
         :param system_name: The system name
@@ -23,8 +32,9 @@ class Client(object):
         :param sas_address: The hostname or IP address of the SAS server to communicate with, (no
                             port)
         :param start: Whether the SAS client should start immediately
+        :param queue_length: The maximum number of messages to queue for sending to SAS
         """
-        self._queue = Queue.Queue()
+        self._queue = Queue.Queue(maxsize=queue_length)
         self._stopper = None
         self._worker = None
 
@@ -83,7 +93,10 @@ class Client(object):
 
     def send(self, message):
         logger.debug("Queueing message for sending:\n%s", str(message))
-        self._queue.put(message)
+        try:
+            self._queue.put(message)
+        except Queue.Full:
+            self._worker.set_discarding()
 
 
 class Trail(object):

--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -132,8 +132,8 @@ class MessageSender(threading.Thread):
                 self._discarding = False
             else:
                 msg += ("There is currently no connection to SAS, so all new SAS logs are "
-                        "currently being discarded.  This will continue until the "
-                        "connection to SAS is restored.")
+                        "being discarded.  This will continue until the connection to SAS "
+                        "is restored.")
             logger.error(msg)
 
     def disconnect(self):

--- a/src/metaswitch/sasclient/sender.py
+++ b/src/metaswitch/sasclient/sender.py
@@ -35,6 +35,7 @@ class MessageSender(threading.Thread):
         # Objects that the thread runs on
         self._stopper = stopper
         self._queue = queue
+        self._discarding = False
 
         # Information needed for Init message
         self._system_name = system_name
@@ -118,6 +119,23 @@ class MessageSender(threading.Thread):
                 self._reconnect_wait = MIN_RECONNECT_WAIT_TIME
                 self._connected = True
 
+        if self._discarding:
+            # Some logs have been discarded prior to this connection attempt.
+            # Make a log to indicate that this has happened, and what is likely
+            # to happen next.
+            msg = ("The SAS client library has filled its message queue, and has discarded "
+                   "some messages.  ")
+
+            if self._connected:
+                msg += ("The connection to SAS is currently active, so the backlog should "
+                        "now clear, allowing new SAS logs to be sent succesfully.")
+                self._discarding = False
+            else:
+                msg += ("There is currently no connection to SAS, so all new SAS logs are "
+                        "currently being discarded.  This will continue until the "
+                        "connection to SAS is restored.")
+            logger.error(msg)
+
     def disconnect(self):
         logger.debug("Disconnecting")
         # It's possible that the socket doesn't even exist yet, so we have nothing to do.
@@ -172,3 +190,13 @@ class MessageSender(threading.Thread):
         # interrupted.
         if not self._stopper.wait(reconnect_wait):
             self.connect()
+
+    def set_discarding(self):
+        logger.debug("SAS message queue full")
+
+        if not self._discarding:
+            # We've just filled the queue and started discarding messages.  Make a log.
+            logger.error("The messge queue is full.  Messages queued for sending to "
+                         "SAS have been discarded")
+
+        self._discarding = True


### PR DESCRIPTION
As discussed, please can you review these changes to limit the SAS client queue length.  I've made the queue size configurable on creating a SAS client object.  In terms of logging:
 - We get a log when the queue first fills up, indicating that the queue is full and messages have started being discarded.
 - We get a log on each connection attempt, indicating when messages have been discarded.
 - The logs will repeatedly remind you that SAS logs are being lost, but this is logged per connection attempt, not per message send attempt.

Other comments:
 - I've gone for a default queue length of 10,000.  It looks like the rust one is hard-coded to 1000.  Do you have strong feelings about the default?
 - There are no UTs, as changes are all in files with no UT coverage.
 - I've tested this with the throw-away script that I used to repro this memory leak.
 - I also intend to test this under the Clearwater stress tests before committing.
